### PR TITLE
Add git revision logging to build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ artifacts {
   archives genJavadoc
 }
 
-task gitVersion() {
-  def cmd = "git rev-pars --short"
+task gitVersion {
+  def cmd = "git rev-pars --short HEAD"
   def pro = cmd.execute()
   ext.revision = pro.text.trim()
   println ext.revision

--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ artifacts {
   archives genJavadoc
 }
 
-task gitVersion {
-  def cmd = "git rev-pars --short HEAD"
+task gitInfo {
+  def cmd = "git rev-parse --short HEAD"
   def pro = cmd.execute()
   ext.revision = pro.text.trim()
   println ext.revision

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ buildscript {
   }
 }
 
+import org.ajoberstar.grgit.*
+
 apply plugin: 'java'
 dependencies {
   compile files('lib/navx_frc.jar')
@@ -32,7 +34,7 @@ ext {
 
 version = "2.0.1.${git.head().abbreviatedId}"             //Get commit abbreviatedId for verision
 mainClassName = "org.usfirst.frc.team5687.robot.Robot"    //Application plugin extension properties
-applicationName = 'Robot'
+applicationName = 'robot'
 
 applicationDistribution.with {
   from('src/dist') {
@@ -45,7 +47,13 @@ applicationDistribution.with {
   }
 }
 
-assemble.dependsOn installDist
+// Contents for src/dist/VERSION:
+/*
+Version: ${version}
+Revision: ${revision}
+Build-date: ${buildDate.format('dd-MM-yyyy HH:mm:ss')}
+Application-name: ${appName}
+*/
 
 //apply plugin: 'eclipse'
 apply plugin: 'GradleRIO'                                 //Apply the GradleRIO plugin
@@ -72,3 +80,6 @@ task genJavadoc(type: Jar, dependsOn: javadoc) {
 artifacts {
   archives genJavadoc
 }
+
+//assemble.dependsOn installDist
+

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
   }
   dependencies {
     classpath group: 'jaci.openrio.gradle', name: 'GradleRIO', version: '+'			//Change this line if you wish to Update GradleRIO
-    classpath 'org.ajoberstar:grgit:1.1.0'
+    classpath 'org.ajoberstar:gradle-git:1.2.0'
   }
 }
 
@@ -31,8 +31,8 @@ ext {
 }
 
 version = "2.0.1.${git.head().abbreviatedId}"             //Get commit abbreviatedId for verision
-mainClassName = 'src.main.java.org.usfirst.frc.team5687.robot.Robot'    //Application plugin extension properties
-applicationName = 'Team 5687'
+mainClassName = "org.usfirst.frc.team5687.robot.Robot"    //Application plugin extension properties
+applicationName = 'Robot'
 
 applicationDistribution.with {
   from('src/dist') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,3 +43,9 @@ artifacts {
   archives genJavadoc
 }
 
+task gitVersion() {
+  def cmd = "git rev-pars --short"
+  def pro = cmd.execute()
+  ext.revision = pro.text.trim()
+  println ext.revision
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,3 @@
-/**
-Template file for classes using GradleRIO
-@author Jaci
-*/
-
 buildscript {
   repositories {
 	mavenCentral()
@@ -13,11 +8,8 @@ buildscript {
   }
   dependencies {
     classpath group: 'jaci.openrio.gradle', name: 'GradleRIO', version: '+'			//Change this line if you wish to Update GradleRIO
-    classpath 'org.ajoberstar:gradle-git:1.2.0'
   }
 }
-
-import org.ajoberstar.grgit.*
 
 apply plugin: 'java'
 dependencies {
@@ -26,36 +18,6 @@ dependencies {
 
 apply plugin: 'idea'
 
-apply plugin: 'application'
-ext {
-  git = org.ajoberstar.grgit.Grgit.open(file('.'))        //Open git repository
-  revision = git.head().id                                //Get commit id for revision
-}
-
-version = "2.0.1.${git.head().abbreviatedId}"             //Get commit abbreviatedId for verision
-mainClassName = "org.usfirst.frc.team5687.robot.Robot"    //Application plugin extension properties
-applicationName = 'robot'
-
-applicationDistribution.with {
-  from('src/dist') {
-    include 'VERSION'
-    expand(
-      buildDate: new Date(),
-      revision: revision,
-      version: project.version,
-      appName: applicationName)
-  }
-}
-
-// Contents for src/dist/VERSION:
-/*
-Version: ${version}
-Revision: ${revision}
-Build-date: ${buildDate.format('dd-MM-yyyy HH:mm:ss')}
-Application-name: ${appName}
-*/
-
-//apply plugin: 'eclipse'
 apply plugin: 'GradleRIO'                                 //Apply the GradleRIO plugin
 
 gradlerio.robotClass = "org.usfirst.frc.team5687.robot.Robot"   //The class for the main Robot Class. Used in manifest
@@ -80,6 +42,4 @@ task genJavadoc(type: Jar, dependsOn: javadoc) {
 artifacts {
   archives genJavadoc
 }
-
-//assemble.dependsOn installDist
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
   }
   dependencies {
     classpath group: 'jaci.openrio.gradle', name: 'GradleRIO', version: '+'			//Change this line if you wish to Update GradleRIO
+    classpath 'org.ajoberstar:grgit:1.1.0'
   }
 }
 
@@ -20,7 +21,32 @@ apply plugin: 'java'
 dependencies {
   compile files('lib/navx_frc.jar')
 }
+
 apply plugin: 'idea'
+
+apply plugin: 'application'
+ext {
+  git = org.ajoberstar.grgit.Grgit.open(file('.'))        //Open git repository
+  revision = git.head().id                                //Get commit id for revision
+}
+
+version = "2.0.1.${git.head().abbreviatedId}"             //Get commit abbreviatedId for verision
+mainClassName = 'src.main.java.org.usfirst.frc.team5687.robot.Robot'    //Application plugin extension properties
+applicationName = 'Team 5687'
+
+applicationDistribution.with {
+  from('src/dist') {
+    include 'VERSION'
+    expand(
+      buildDate: new Date(),
+      revision: revision,
+      version: project.version,
+      appName: applicationName)
+  }
+}
+
+assemble.dependsOn installDist
+
 //apply plugin: 'eclipse'
 apply plugin: 'GradleRIO'                                 //Apply the GradleRIO plugin
 


### PR DESCRIPTION
Logs the git revision to terminal by using `gradlew -q gitInfo` for Windows, or `./gradlew -q gitInfo` for Mac or Linux.

Will close #23 
