### PR TITLE
Show uncommitted changes status when deploy code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,23 +52,21 @@ def getTimestamp = {
 task gitInfo(dependsOn: build) {
   description = 'When build, logs the branch and version to build'
   def cmd = "git rev-parse --abbrev-ref HEAD"
-  ext.branch = cmd.execute().text.trim()
+  project.ext.branch = cmd.execute().text.trim()
   cmd = "git rev-parse --short HEAD"
-  ext.revision = cmd.execute().text.trim()
+  project.ext.set("revision", cmd.execute().text.trim())
 
-  project.ext.set("branch", ext.branch)
-  project.ext.set("revision", ext.revision)
   println "[branch] " + project.branch
   println "[commit] " + project.revision
 }
 
 task gitLog << {
   description = 'When deploy, logs and overwrites branch and version to a log file'
-  def cmdFile = new File('src/main/java/org/usfirst/frc/team5687/robot/utils/Reader.java')
+  def logFile = new File('src/main/java/org/usfirst/frc/team5687/robot/utils/Reader.java')
   def br = "\n\n"
-  def pck = "package org.usfirst.frc.team5687.robot.utils;" + br
-  def jvd = "/**\n * A file reader class to read current Git information from deployed robot code\n * @author wilstenholme\n */" + br
-  def reader = "public class Reader {\n" + "    public static final String gitInfo = \"" + project.branch + " " + project.revision + "\";\n }"
-  cmdFile.text = pck + jvd + reader
+  def reader = "package org.usfirst.frc.team5687.robot.utils;" + br
+  reader += "/**\n * A file reader class to read current Git information from deployed robot code\n * @author wilstenholme\n */" + br
+  reader += "public class Reader {\n" + "    public static final String gitInfo = \"" + project.branch + " " + project.revision + "\";\n }"
+  logFile.text = reader
 }
 deploy.dependsOn(gitLog)

--- a/build.gradle
+++ b/build.gradle
@@ -54,25 +54,30 @@ task gitInfo(dependsOn: build) {
   def cmd = "git rev-parse --abbrev-ref HEAD"
   project.ext.branch = cmd.execute().text.trim()
   cmd = "git rev-parse --short HEAD"
-  project.ext.set("revision", cmd.execute().text.trim())
+  project.ext.revision = cmd.execute().text.trim()
 
   println "[branch] " + project.branch
   println "[commit] " + project.revision
 
-  cmd = "git diff --shortstat"
-  def changes = cmd.execute().text.trim()
-  if (changes != null && changes.length() != 0) {
-    println "[modifed] " + changes.substring(0, 1)
+  cmd = "git diff HEAD --shortstat"
+  def mod = cmd.execute().text.trim()
+  if (mod != null && mod.length() != 0) {
+    project.ext.modified = mod.substring(0, 1)
+    println "[modifed] " + project.modified
   }
 }
 
 task gitLog << {
   description = 'When deploy, logs and overwrites branch and version to a log file'
   def logFile = new File('src/main/java/org/usfirst/frc/team5687/robot/utils/Reader.java')
+  def mod = ""
+  if (project.modified != null & project.modified.length() != 0) {
+    mod = " *"
+  }
   def br = "\n\n"
   def reader = "package org.usfirst.frc.team5687.robot.utils;" + br
   reader += "/**\n * A file reader class to read current Git information from deployed robot code\n * @author wilstenholme\n */" + br
-  reader += "public class Reader {\n" + "    public static final String gitInfo = \"" + project.branch + " " + project.revision + "\";\n }"
+  reader += "public class Reader {\n" + "    public static final String gitInfo = \"" + project.branch + " " + project.revision + mod + "\";\n }"
   logFile.text = reader
 }
 deploy.dependsOn(gitLog)

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,12 @@ task gitInfo(dependsOn: build) {
 
   println "[branch] " + project.branch
   println "[commit] " + project.revision
+
+  cmd = "git diff --shortstat"
+  def changes = cmd.execute().text.trim()
+  if (changes != null && changes.length() != 0) {
+    println "[modifed] " + changes.substring(0, 1)
+  }
 }
 
 task gitLog << {

--- a/build.gradle
+++ b/build.gradle
@@ -58,26 +58,19 @@ task gitInfo(dependsOn: build) {
 
   println "[branch] " + project.branch
   println "[commit] " + project.revision
-
-  cmd = "git diff HEAD --shortstat"
-  def mod = cmd.execute().text.trim()
-  if (mod != null && mod.length() != 0) {
-    project.ext.modified = mod.substring(0, 1)
-    println "[modifed] " + project.modified
-  }
 }
 
 task gitLog << {
   description = 'When deploy, logs and overwrites branch and version to a log file'
   def logFile = new File('src/main/java/org/usfirst/frc/team5687/robot/utils/Reader.java')
-  def mod = ""
-  if (project.modified != null & project.modified.length() != 0) {
-    mod = " *"
-  }
+
+  def cmd = "git diff HEAD --shortstat"
+  def mod = cmd.execute().text.trim()
+  def modified = (mod != null && mod.length() != 0) ? " *" : ""
   def br = "\n\n"
   def reader = "package org.usfirst.frc.team5687.robot.utils;" + br
   reader += "/**\n * A file reader class to read current Git information from deployed robot code\n * @author wilstenholme\n */" + br
-  reader += "public class Reader {\n" + "    public static final String gitInfo = \"" + project.branch + " " + project.revision + mod + "\";\n }"
+  reader += "public class Reader {\n" + "    public static final String gitInfo = \"" + project.branch + " " + project.revision + modified + "\";\n }"
   logFile.text = reader
 }
 deploy.dependsOn(gitLog)


### PR DESCRIPTION
From #45,
When robot code is deployed, the git `branch` and `revision` is sent to the Smart Dashboard.

This pull request adds a status `(*)` if the version of deployed code contains uncommitted changes. 
In other words, if the current copy of roboRIO's code is not committed, partially or entirely, an asterisk is shown after the git information.
