### PR TITLE
Restore default commit log

### DIFF
--- a/src/main/java/org/usfirst/frc/team5687/robot/utils/Reader.java
+++ b/src/main/java/org/usfirst/frc/team5687/robot/utils/Reader.java
@@ -2,9 +2,15 @@ package org.usfirst.frc.team5687.robot.utils;
 
 /**
  * A file reader class to read current Git information from deployed robot code
+ * When code is deployed, the Reader class updates gitInfo to the current branch and commit
+ *
+ * DO NOT COMMIT THIS FILE, THIS IS FOR LOGGING PURPOSES ONLY
+ * To untrack this file locally, in root directory, use
+ * git update-index --skip-worktree src/main/java/org/usfirst/frc/team5687/robot/utils/Reader.java
+ *
  * @author wilstenholme
  */
 
 public class Reader {
-    public static final String gitInfo = "autonomous/#123-traverselowbar 788710c *";
- }
+    public static final String gitInfo = "default commit";
+}


### PR DESCRIPTION
Restore to avoid conflicts on devices with log file untracked
