### PR TITLE
High Goal shooter speed relies on new SendableChooser

### DIFF
--- a/src/main/java/org/usfirst/frc/team5687/robot/Constants.java
+++ b/src/main/java/org/usfirst/frc/team5687/robot/Constants.java
@@ -104,9 +104,14 @@ public class Constants {
         public static final long UNPRIME_TIME = 1500;
 
         /**
-         * Speed to run the shooter wheels to shoot high goal
+         * Speed to run the shooter wheels to shoot a high goal with a new boulder
          */
-        public static final double SHOOTER_SPEED = .94;
+        public static final double NEW_SHOOTER_SPEED = .94;
+
+        /**
+         * Speed to run the shooter wheels to shoot a high goal with an old/worn boulder
+         */
+        public static final double OLD_SHOOTER_SPEED = 0.94;
     }
 
     public class Arms {

--- a/src/main/java/org/usfirst/frc/team5687/robot/Constants.java
+++ b/src/main/java/org/usfirst/frc/team5687/robot/Constants.java
@@ -111,7 +111,7 @@ public class Constants {
         /**
          * Speed to run the shooter wheels to shoot a high goal with an old/worn boulder
          */
-        public static final double OLD_SHOOTER_SPEED = 0.94;
+        public static final double OLD_SHOOTER_SPEED = 1.0;
     }
 
     public class Arms {

--- a/src/main/java/org/usfirst/frc/team5687/robot/Robot.java
+++ b/src/main/java/org/usfirst/frc/team5687/robot/Robot.java
@@ -73,6 +73,7 @@ public class Robot extends IterativeRobot {
 
     public SendableChooser defenseChooser;
     public SendableChooser positionChooser;
+    public SendableChooser boulderCondition;
 
     CustomCameraServer cameraServer;
 
@@ -95,6 +96,7 @@ public class Robot extends IterativeRobot {
         autoChooser = new SendableChooser();
         defenseChooser = new SendableChooser();
         positionChooser = new SendableChooser();
+        boulderCondition = new SendableChooser();
 
         powerDistributionPanel = new PowerDistributionPanel();
 
@@ -146,6 +148,10 @@ public class Robot extends IterativeRobot {
         autoChooser.addObject("Drive 48", new AutoDrive(-.4, 48f));
         autoChooser.addObject("Drive 96", new AutoDrive(-.4, 96f));
         SmartDashboard.putData("Autonomous mode", autoChooser);
+
+        boulderCondition.addDefault("New Boulder", "1");
+        boulderCondition.addObject("Old Boulder", "2");
+        SmartDashboard.putData("Boulder Condition", boulderCondition);
 
 
         //Setup Camera Code
@@ -282,6 +288,10 @@ public class Robot extends IterativeRobot {
 
     public String getSelectedPosition() {
         return (String) positionChooser.getSelected();
+    }
+
+    public String getBoulderCondition() {
+        return (String) boulderCondition.getSelected();
     }
 
 

--- a/src/main/java/org/usfirst/frc/team5687/robot/commands/Prime.java
+++ b/src/main/java/org/usfirst/frc/team5687/robot/commands/Prime.java
@@ -1,7 +1,9 @@
 package org.usfirst.frc.team5687.robot.commands;
 
 import edu.wpi.first.wpilibj.command.CommandGroup;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import org.usfirst.frc.team5687.robot.Constants;
+import org.usfirst.frc.team5687.robot.Robot;
 
 /**
  * Command group to prime the shooter subsystem
@@ -9,8 +11,16 @@ import org.usfirst.frc.team5687.robot.Constants;
  */
 public class Prime extends CommandGroup{
 
+    private double SHOOTER_SPEED;
+
     public Prime() {
+        if (Robot.robot.getBoulderCondition().equals("2")) {
+            SHOOTER_SPEED = Constants.Shooter.OLD_SHOOTER_SPEED;
+        } else {
+            SHOOTER_SPEED = Constants.Shooter.NEW_SHOOTER_SPEED;
+        }
+
         addSequential(new PrimeBoulder());
-        addSequential(new SetShooterSpeed(Constants.Shooter.SHOOTER_SPEED, Constants.Shooter.PRIME_TIME));
+        addSequential(new SetShooterSpeed(SHOOTER_SPEED, Constants.Shooter.PRIME_TIME));
     }
 }


### PR DESCRIPTION
There should be a new chooser on the smart dashboard where you can choose between a new and an old/worn boulder.

The speed for shooting a new ball is the same as the speed for shooting an old ball right now. They are found in Constants.java and that should be the only modifications required before merging.

Fixes #141 
